### PR TITLE
Add correlation adapter

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ Version History
 `1.1.0`_
 ~~~~~~~~
 - Make ``sprockets.mixins.correlation.HandlerMixin.prepare`` async
+- Add ``sprockets.mixins.correlation.CorrelationAdapter``
 
 `1.0.1`_ (31-Mar-2015)
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,8 +1,8 @@
 Version History
 ---------------
 
-`1.1.0`_
-~~~~~~~~
+`1.1.0`_ (23-Sep-2015)
+~~~~~~~~~~~~~~~~~~~~~~
 - Make ``sprockets.mixins.correlation.HandlerMixin.prepare`` async
 - Add ``sprockets.mixins.correlation.CorrelationAdapter``
 - Add ``sprockets.mixins.correlation.LoggingMixin``

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,9 +1,14 @@
 Version History
 ---------------
 
+`1.1.0`_
+~~~~~~~~
+- Make ``sprockets.mixins.correlation.HandlerMixin.prepare`` async
+
 `1.0.1`_ (31-Mar-2015)
 ~~~~~~~~~~~~~~~~~~~~~~
  - Adds ``sprockets.mixins.correlation.HandlerMixin``
 
 
+.. _`1.1.0`: https://github.com/sprockets/sprockets.mixins.correlation/compare/1.0.1...1.1.0
 .. _`1.0.1`: https://github.com/sprockets/sprockets.mixins.correlation/compare/0.0.0...1.0.1

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,10 +5,11 @@ Version History
 ~~~~~~~~
 - Make ``sprockets.mixins.correlation.HandlerMixin.prepare`` async
 - Add ``sprockets.mixins.correlation.CorrelationAdapter``
+- Add ``sprockets.mixins.correlation.LoggingMixin``
 
 `1.0.1`_ (31-Mar-2015)
 ~~~~~~~~~~~~~~~~~~~~~~
- - Adds ``sprockets.mixins.correlation.HandlerMixin``
+ - Add ``sprockets.mixins.correlation.HandlerMixin``
 
 
 .. _`1.1.0`: https://github.com/sprockets/sprockets.mixins.correlation/compare/1.0.1...1.1.0

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,6 +9,9 @@ API Documentation
 .. autoclass:: sprockets.mixins.correlation.CorrelationAdapter
    :members:
 
+.. autoclass:: sprockets.mixins.correlation.LoggingMixin
+   :members:
+
 Contributing to this Library
 ----------------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,9 +3,10 @@
 API Documentation
 -----------------
 
-correlation.HandlerMixin
-~~~~~~~~~~~~~~~~~~~~~~~~
 .. autoclass:: sprockets.mixins.correlation.HandlerMixin
+   :members:
+
+.. autoclass:: sprockets.mixins.correlation.CorrelationAdapter
    :members:
 
 Contributing to this Library

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 import codecs
-import sys
 
 import setuptools
 

--- a/sprockets/mixins/correlation/__init__.py
+++ b/sprockets/mixins/correlation/__init__.py
@@ -1,9 +1,12 @@
 try:
-    from .mixins import HandlerMixin
+    from .mixins import CorrelationAdapter, HandlerMixin
 
 # the following makes importing the module possible when tornado
 # is not installed in the active environment
 except ImportError as exc:  # pragma no cover
+    def CorrelationAdapter(*args, **kwargs):
+        raise exc
+
     def HandlerMixin(*args, **kwargs):
         raise exc
 

--- a/sprockets/mixins/correlation/__init__.py
+++ b/sprockets/mixins/correlation/__init__.py
@@ -1,5 +1,12 @@
-from .mixins import HandlerMixin
+try:
+    from .mixins import HandlerMixin
+
+# the following makes importing the module possible when tornado
+# is not installed in the active environment
+except ImportError as exc:  # pragma no cover
+    def HandlerMixin(*args, **kwargs):
+        raise exc
 
 
-version_info = (1, 0, 1)
+version_info = (1, 1, 0)
 __version__ = '.'.join(str(v) for v in version_info[:3])

--- a/sprockets/mixins/correlation/__init__.py
+++ b/sprockets/mixins/correlation/__init__.py
@@ -1,5 +1,5 @@
 try:
-    from .mixins import CorrelationAdapter, HandlerMixin
+    from .mixins import CorrelationAdapter, HandlerMixin, LoggingMixin
 
 # the following makes importing the module possible when tornado
 # is not installed in the active environment
@@ -8,6 +8,9 @@ except ImportError as exc:  # pragma no cover
         raise exc
 
     def HandlerMixin(*args, **kwargs):
+        raise exc
+
+    def LoggingMixin(*args, **kwargs):
         raise exc
 
 

--- a/sprockets/mixins/correlation/mixins.py
+++ b/sprockets/mixins/correlation/mixins.py
@@ -1,5 +1,7 @@
 import uuid
 
+from tornado import gen, log
+
 
 class HandlerMixin(object):
     """
@@ -39,11 +41,15 @@ class HandlerMixin(object):
         self.__correlation_id = str(uuid.uuid4())
         super(HandlerMixin, self).__init__(*args, **kwargs)
 
+    @gen.coroutine
     def prepare(self):
         # Here we want to copy an incoming Correlation-ID header if
         # one exists.  We also want to set it in the outgoing response
         # which the property setter does for us.
-        super(HandlerMixin, self).prepare()
+        maybe_future = super(HandlerMixin, self).prepare()
+        if maybe_future:
+            yield maybe_future
+
         correlation_id = self.get_request_header(self.__header_name, None)
         if correlation_id is not None:
             self.correlation_id = correlation_id

--- a/sprockets/mixins/correlation/mixins.py
+++ b/sprockets/mixins/correlation/mixins.py
@@ -1,3 +1,4 @@
+import logging
 import uuid
 
 from tornado import gen, log
@@ -87,6 +88,32 @@ class HandlerMixin(object):
 
         """
         return self.request.headers.get(name, default)
+
+
+class CorrelationAdapter(logging.LoggerAdapter):
+    """
+    Adapt a :class:`logging.Logger` to include a correlation ID.
+
+    .. attribute:: correlation_id
+
+       Identifier that is appended to each log message if it is
+       set to a *truthy* value.
+
+    This simple adapter extends :class:`logging.LogAdapter` to insert
+    the :attr:`correlation_id` value into every message.  By default
+    the attribute's value is :data:`None`.  Set it to something else
+    in your ``prepare`` method if you are using the :class:`.LoggingMixin`.
+
+    """
+
+    def __init__(self, logger, extra=None):
+        self.correlation_id = None
+        logging.LoggerAdapter.__init__(self, logger, extra or {})
+
+    def process(self, msg, kwargs):
+        if self.correlation_id:
+            msg += ' {CID %s}' % (self.correlation_id, )
+        return logging.LoggerAdapter.process(self, msg, kwargs)
 
 
 def correlation_id_logger(handler):

--- a/tests.py
+++ b/tests.py
@@ -1,12 +1,18 @@
 import uuid
-import unittest
 
-from tornado import testing, web
+from tornado import gen, testing, web
 
 from sprockets.mixins import correlation
 
 
-class CorrelatedRequestHandler(correlation.HandlerMixin, web.RequestHandler):
+class AsyncPreparer(web.RequestHandler):
+
+    @gen.coroutine
+    def prepare(self):
+        super(AsyncPreparer, self).prepare()
+
+
+class CorrelatedRequestHandler(correlation.HandlerMixin, AsyncPreparer):
 
     def get(self, status_code):
         status_code = int(status_code)


### PR DESCRIPTION
This PR adds a new mixin that installs a `logging.Logger` instance as `self.logger` that appends the correlation ID to all logged requests.  I've also made the `HandlerMixin.prepare` correctly work with co-routines.
