### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,7 +80,7 @@ Relayed Correlation ID
    :target: http://coveralls.io/r/sprockets/sprockets.mixins.correlation
 .. |Downloads| image:: https://img.shields.io/pypi/dm/sprockets.mixins.correlation.svg
    :target: https://pypi.python.org/pypi/sprockets.mixins.correlation
-.. |License| image:: https://pypip.in/license/sprockets.mixins.correlation/badge.svg
+.. |License| image:: https://img.shields.io/pypi/l/sprockets.mixins.correlation.svg
    :target: https://sprocketsmixinscorrelation.readthedocs.io/
 .. |Documentation| image:: https://readthedocs.org/projects/sprocketsmixinscorrelation/badge
    :target: https://sprocketsmixinscorrelation.readthedocs.io/


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20sprockets-mixins-correlation))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `sprockets-mixins-correlation`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.