### PR TITLE
Fix async coroutine execution in HandlerMixin.prepare()

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,11 @@
 Version History
 ---------------
 
+`3.0.0`_ (18-Dec-2019)
+~~~~~~~~~~~~~~~~~~~~~~
+- Dropped support for Tornado 4
+- Fixed support for async prepare in superclasses of ``HandlerMixin``
+
 `2.0.1`_ (18-Mar-2019)
 ~~~~~~~~~~~~~~~~~~~~~~
 - Add support for Tornado 6
@@ -21,6 +26,7 @@ Version History
 ~~~~~~~~~~~~~~~~~~~~~~
  - Adds ``sprockets.mixins.correlation.HandlerMixin``
 
+.. _`3.0.0`: https://github.com/sprockets/sprockets.mixins.correlation/compare/3.0.0...2.0.1
 .. _`2.0.1`: https://github.com/sprockets/sprockets.mixins.correlation/compare/2.0.0...2.0.1
 .. _`2.0.0`: https://github.com/sprockets/sprockets.mixins.correlation/compare/1.0.2...2.0.0
 .. _`1.0.2`: https://github.com/sprockets/sprockets.mixins.correlation/compare/1.0.1...1.0.2

--- a/requires/installation.txt
+++ b/requires/installation.txt
@@ -1,1 +1,1 @@
-tornado>=4.3,<7
+tornado>=5,<7

--- a/sprockets/mixins/correlation/__init__.py
+++ b/sprockets/mixins/correlation/__init__.py
@@ -7,5 +7,5 @@ except ImportError:
             raise ImportError
 
 
-version_info = (2, 0, 1)
+version_info = (3, 0, 0)
 __version__ = '.'.join(str(v) for v in version_info[:3])

--- a/sprockets/mixins/correlation/mixins.py
+++ b/sprockets/mixins/correlation/mixins.py
@@ -1,6 +1,7 @@
+import asyncio
 import uuid
 
-from tornado import concurrent, log
+from tornado import log
 
 
 class HandlerMixin(object):
@@ -45,9 +46,9 @@ class HandlerMixin(object):
         # Here we want to copy an incoming Correlation-ID header if
         # one exists.  We also want to set it in the outgoing response
         # which the property setter does for us.
-        maybe_future = super(HandlerMixin, self).prepare()
-        if concurrent.is_future(maybe_future):
-            await maybe_future
+        maybe_coro = super(HandlerMixin, self).prepare()
+        if asyncio.iscoroutine(maybe_coro):
+            await maybe_coro
 
         correlation_id = self.get_request_header(self.__header_name, None)
         if correlation_id is not None:


### PR DESCRIPTION
**The Problem**

Assume that you define a class that uses HandlerMixin, and that class defines a prepare function using `async def prepare`.

The HandlerMixin class's prepare() function failed to recognize that super().prepare() was a coroutine that needed to be awaited.

**A Solution**

In the HandlerMixin class's prepare() function, replaced Tornado's `coroutine.is_future` returned False where `asyncio.iscoroutine`.

Dropped support for Tornado 4.3.

**Other Things to Note**

Considering that the prepare() function already uses `async def` instead of a Tornado `gen.coroutine` decorator, it seems clear that this module embraced asyncio just like Tornado has.  This is 1 more step in that direction.