### PR TITLE
Remove AsyncIOHandlerMixin class from Sphinx documentation.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,10 +8,6 @@ correlation.HandlerMixin
 .. autoclass:: sprockets.mixins.correlation.HandlerMixin
    :members:
 
-.. autoclass:: sprockets.mixins.correlation.AsyncIOHandlerMixin
-   :members:
-
-
 Contributing to this Library
 ----------------------------
 


### PR DESCRIPTION
**Why?**
That class does not appear to exist.

**What problem does this solve?**
`setup.py build_sphinx` failed. That blocks a release of v3.0.0 to PyPI.